### PR TITLE
The 'activated_plugins' default value changed to empty list

### DIFF
--- a/plone/app/ldap/engine/storage.py
+++ b/plone/app/ldap/engine/storage.py
@@ -30,7 +30,7 @@ class LDAPConfiguration(OrderedContainer):
     default_user_roles = "Member"
     read_only = False
     activated_interfaces = []
-    activated_plugins = None
+    activated_plugins = []
     cache = ''
     
     def __init__(self):


### PR DESCRIPTION
The 'activated_plugins' default value should be an empty list instead of None, becouse it's expected to be an iterable type in other places in the code (for example: https://github.com/plone/plone.app.ldap/blob/master/plone/app/ldap/ploneldap/util.py#L173)
