### PR TITLE
Fixes Issue #11, Plone uses now png instead gif graphics

### DIFF
--- a/plone/app/ldap/browser/controlpanel.pt
+++ b/plone/app/ldap/browser/controlpanel.pt
@@ -272,7 +272,7 @@
                                  tal:attributes="value server/id" />
                              </td>
                              <td class="checker">
-                               <img tal:replace="structure context/confirm_icon.gif"
+                               <img tal:replace="structure context/confirm_icon.png"
                                     tal:condition="server/enabled" />
                              </td>
                              <td>


### PR DESCRIPTION
fixed extension of includes images: uses png now
