### PR TITLE
AD & other misc. fixes

### DIFF
--- a/plone/app/ldap/browser/controlpanel.pt
+++ b/plone/app/ldap/browser/controlpanel.pt
@@ -132,14 +132,16 @@
              <p i18n:translate="description-schema">
              The LDAP schema defines the LDAP properties which can be used
              by the Plone. Properties with a Plone property name will be
-             available as standard user properties in Plone. Properties without
-             a Plone property name can be used as user id, login name or
+             available as standard user properties in Plone (see
+             portal_memberdata in the ZMI for a list). Any property which is
+             not multi-valued can be used as the user id, login name or
              relative DN by the LDAP configuration.
              </p>
 
              <p i18n:translate="description-schema-protected">
-             As a safety precaution attributes that are used as login, user or rDN
-             attribute can not be removed.
+             As a safety precaution, attributes that are used as the user id,
+             login name, or rDN attribute or are required for Active Directory
+             cannot be removed.
              </p>
 
              <form style="display: inline" method="POST"

--- a/plone/app/ldap/browser/controlpanel.py
+++ b/plone/app/ldap/browser/controlpanel.py
@@ -211,9 +211,10 @@ class LDAPControlPanel(EditForm):
         storage=self.storage
 
         def protected(attr):
-            return attr.__name__ in (storage.rdn_attribute,
-                                     storage.userid_attribute,
-                                     storage.login_attribute)
+            return attr.__name__ in storage.required_attributes + [
+                    storage.rdn_attribute,
+                    storage.userid_attribute,
+                    storage.login_attribute]
 
         return [dict(id=p.__name__,
                      description=p.description,

--- a/plone/app/ldap/engine/interfaces.py
+++ b/plone/app/ldap/engine/interfaces.py
@@ -109,10 +109,10 @@ class ILDAPBinding(Interface):
                 default=u"Search scope for users"),
             description=_(u"help_ldap_user_scope",
                 default=u"The search scope determines where the LDAP server "
-                        u"will search for users. With BASE it will only look "
-                        u"for users who directly in the user base location. "
-                        u"SUBTREE will allow the server to also look in "
-                        u"subfolders of the user base location."),
+                        u"will search for users. With \"one level\" it will "
+                        u"only look for users directly in the user base "
+                        u"location; \"subtree\" will allow the server to also "
+                        u"look in subfolders of the user base location."),
             default=SCOPE_SUBTREE,
             vocabulary="plone.app.ldap.engine.LDAPScopes",
             required=True)
@@ -136,10 +136,10 @@ class ILDAPBinding(Interface):
                 default=u"Search scope for groups"),
             description=_(u"help_ldap_group_scope",
                 default=u"The search scope determines where the LDAP server "
-                        u"will search for groups. With BASE it will only look "
-                        u"for users who directly in the group base location. "
-                        u"SUBTREE will allow the server to also look in "
-                        u"subfolders of the group base location."),
+                        u"will search for groups. With \"one level\" it will "
+                        u"only look for groups directly in the group base "
+                        u"location; \"subtree\" will allow the server to also "
+                        u"look in subfolders of the group base location."),
             default=SCOPE_SUBTREE,
             vocabulary="plone.app.ldap.engine.LDAPScopes",
             required=True)
@@ -148,7 +148,7 @@ class ILDAPBinding(Interface):
             title =_(u"label_ldap_user_password_encryption",
                 default=u"User password encryption"),
             description=_(u"help_ldap_user_password_encryption",
-                default=u"Method of encryption used for user passwords"),
+                default=u"Method of encryption used for user passwords."),
             default="crypt",
             vocabulary="plone.app.ldap.engine.LDAPPasswordEncryption",)
 
@@ -156,7 +156,7 @@ class ILDAPBinding(Interface):
             title=_(u"label_ldap_default_user_roles",
                 default=u"Default user roles"),
             description=_(u"help_ldap_default_user_roles",
-                default=u"Default roles for new users"),
+                default=u"Default roles for new users."),
             default="Member",
             required=True,)
 
@@ -275,9 +275,9 @@ class ILDAPPropertyConfiguration(Interface):
                 default= u"Plone property name"),
             description=_(u"help_plone_property",
                 default=u"The name of the property as used in the Plone site. "
-                        u"If no name is specified the property will not be "
-                        u"visible in Plone but still be used as login name, "
-                        u"user id or rDN."),
+                        u"If no name is specified, the property will not be "
+                        u"visible in Plone but may still be used as the login "
+                        u"name, user id, or rDN."),
             required=False)
 
     multi_valued = Bool(

--- a/plone/app/ldap/engine/schema.py
+++ b/plone/app/ldap/engine/schema.py
@@ -21,6 +21,5 @@ class LDAPProperty(SimpleItem):
         if name in ('ldap_name', 'plone_name', 'description'):
             # Store blank fields as empty strings to avoid exporting a
             # literal 'None' with e.g. str(property.attr).
-            self.__dict__[name] = value or u""
-        else:
-            self.__dict__[name] = value
+            value = value or u""
+        super(LDAPProperty, self).__setattr__(name, value)

--- a/plone/app/ldap/engine/schema.py
+++ b/plone/app/ldap/engine/schema.py
@@ -16,3 +16,11 @@ class LDAPProperty(SimpleItem):
         self.plone_name=plone_name
         self.multi_valued=multi_valued
         self.binary=binary
+
+    def __setattr__(self, name, value):
+        if name in ('ldap_name', 'plone_name', 'description'):
+            # Store blank fields as empty strings to avoid exporting a
+            # literal 'None' with e.g. str(property.attr).
+            self.__dict__[name] = value or u""
+        else:
+            self.__dict__[name] = value

--- a/plone/app/ldap/engine/storage.py
+++ b/plone/app/ldap/engine/storage.py
@@ -28,7 +28,6 @@ class LDAPConfiguration(OrderedContainer):
     password_encryption = "crypt"
     default_user_roles = "Member"
     read_only = False
-    activated_interfaces = []
     activated_plugins = []
     cache = ''
 

--- a/plone/app/ldap/engine/storage.py
+++ b/plone/app/ldap/engine/storage.py
@@ -16,6 +16,7 @@ class LDAPConfiguration(OrderedContainer):
     rdn_attribute = "uid"
     userid_attribute = "uid"
     login_attribute = "uid"
+    required_attributes = []
 
     user_object_classes = "pilotPerson"
 

--- a/plone/app/ldap/engine/vocabulary.py
+++ b/plone/app/ldap/engine/vocabulary.py
@@ -64,7 +64,7 @@ class LDAPAttributesVocabulary(object):
 LDAPAttributesVocabularyFactory = LDAPAttributesVocabulary()
 
 
-class LDAPSinglueValueAttributesVocabulary(object):
+class LDAPSingleValueAttributesVocabulary(object):
     """Vocabulary factory for LDAP attributes.
     """
     implements(IVocabularyFactory)
@@ -75,7 +75,7 @@ class LDAPSinglueValueAttributesVocabulary(object):
                     if not a.multi_valued]
         return SimpleVocabulary.fromItems(sorted(attributes))
 
-LDAPSingleValueAttributesVocabularyFactory = LDAPAttributesVocabulary()
+LDAPSingleValueAttributesVocabularyFactory = LDAPSingleValueAttributesVocabulary()
 
 
 class LDAPPasswordEncryptionVocabulary(object):

--- a/plone/app/ldap/ploneldap/schema.py
+++ b/plone/app/ldap/ploneldap/schema.py
@@ -48,4 +48,3 @@ def HandleRemoved(property, event):
 
     luf=getLDAPPlugin()._getLDAPUserFolder()
     luf.manage_deleteLDAPSchemaItems([str(property.ldap_name)])
-    configureLDAPSchema()

--- a/plone/app/ldap/ploneldap/schema.py
+++ b/plone/app/ldap/ploneldap/schema.py
@@ -48,4 +48,4 @@ def HandleRemoved(property, event):
 
     luf=getLDAPPlugin()._getLDAPUserFolder()
     luf.manage_deleteLDAPSchemaItems([str(property.ldap_name)])
-    addMandatorySchemaItems()
+    configureLDAPSchema()

--- a/plone/app/ldap/ploneldap/util.py
+++ b/plone/app/ldap/ploneldap/util.py
@@ -130,7 +130,8 @@ def configureLDAPSchema():
                 ldap_name=str(property.ldap_name),
                 friendly_name=property.description,
                 public_name=str(property.plone_name),
-                multivalued=property.multi_valued)
+                multivalued=property.multi_valued,
+                binary=property.binary)
     luf.setSchemaConfig(schema)
     addMandatorySchemaItems()
 

--- a/plone/app/ldap/ploneldap/util.py
+++ b/plone/app/ldap/ploneldap/util.py
@@ -107,8 +107,9 @@ def addMandatorySchemaItems():
 
     if config.ldap_type==u"AD":
         required = [("dn", "Distinguished Name"),
-                    ("objectGUID", "AD Object GUID"),
+                    ("objectGUID", "AD Object GUID", False, '', True),
                     ("cn", "Canonical Name"),
+                    ("sAMAccountName", "AD User Name"),
                     ("memberOf", "Group DNs", True, "memberOf")]
     else:
         required = []

--- a/plone/app/ldap/ploneldap/util.py
+++ b/plone/app/ldap/ploneldap/util.py
@@ -166,18 +166,18 @@ def enablePASInterfaces():
         else:
             plugin.manage_activateInterfaces(ldap_interfaces)
 
-    if config.ldap_type != u"AD":
-        plugins=getPAS().plugins
+    plugins=getPAS().plugins
+    if "IPropertiesPlugin" in config.activated_plugins:
+        iface=plugins._getInterfaceFromName("IPropertiesPlugin")
+        for i in range(len(plugins.listPlugins(iface))-1):
+            plugins.movePluginsUp(iface, [plugin.getId()])
 
+    if config.ldap_type != u"AD":
         if "IUserAdderPlugin" in config.activated_plugins:
             iface=plugins._getInterfaceFromName("IUserAdderPlugin")
             for i in range(len(plugins.listPlugins(iface))-1):
                 plugins.movePluginsUp(iface, [plugin.getId()])
 
-        if "IPropertiesPlugin" in config.activated_plugins:
-            iface=plugins._getInterfaceFromName("IPropertiesPlugin")
-            for i in range(len(plugins.listPlugins(iface))-1):
-                plugins.movePluginsUp(iface, [plugin.getId()])
 
 
 def enableCaching(cache_manager="RAMCache"):

--- a/plone/app/ldap/ploneldap/util.py
+++ b/plone/app/ldap/ploneldap/util.py
@@ -165,8 +165,10 @@ def enablePASInterfaces():
     else:
         if config.ldap_type==u"AD":
             plugin.manage_activateInterfaces(ad_interfaces)
+            config.activated_plugins = ad_interfaces
         else:
             plugin.manage_activateInterfaces(ldap_interfaces)
+            config.activated_plugins = ldap_interfaces
 
     plugins=getPAS().plugins
     if "IPropertiesPlugin" in config.activated_plugins:

--- a/plone/app/ldap/ploneldap/util.py
+++ b/plone/app/ldap/ploneldap/util.py
@@ -180,10 +180,11 @@ def enablePASInterfaces():
             plugins.movePluginsUp(iface, [plugin.getId()])
 
     if config.ldap_type != u"AD":
-        if "IUserAdderPlugin" in config.activated_plugins:
-            iface=plugins._getInterfaceFromName("IUserAdderPlugin")
-            for i in range(len(plugins.listPlugins(iface))-1):
-                plugins.movePluginsUp(iface, [plugin.getId()])
+        for p in ("IUserAdderPlugin", "IGroupManagement"):
+            if p in config.activated_plugins:
+                iface=plugins._getInterfaceFromName(p)
+                for i in range(len(plugins.listPlugins(iface))-1):
+                    plugins.movePluginsUp(iface, [plugin.getId()])
 
 
 

--- a/plone/app/ldap/ploneldap/util.py
+++ b/plone/app/ldap/ploneldap/util.py
@@ -119,6 +119,8 @@ def addMandatorySchemaItems():
     for attr, args in required:
         if attr not in config.schema:
             config.schema.addItem(LDAPProperty(ldap_name=attr, **args))
+        if attr not in config.required_attributes:
+            config.required_attributes.append(attr)
 
 
 def configureLDAPSchema():

--- a/plone/app/ldap/profiles/default/actionicons.xml
+++ b/plone/app/ldap/profiles/default/actionicons.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<action-icons xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="plone">
- <action-icon category="controlpanel"
-              action_id="ldap"
-              title="LDAP Connection" priority="0"
-              icon_expr="/misc_/PloneLDAP/ldapmultiplugin.png"
-              i18n:attributes="title"/>
-</action-icons>

--- a/plone/app/ldap/profiles/default/controlpanel.xml
+++ b/plone/app/ldap/profiles/default/controlpanel.xml
@@ -4,6 +4,7 @@
         name="portal_controlpanel">
  <configlet title="LDAP Connection" action_id="ldap" appId="Plone"
     category="Products" condition_expr=""
+    icon_expr="misc_/PloneLDAP/ldapmultiplugin.png"
     url_expr="string:${portal_url}/@@ldap-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Manage portal</permission>


### PR DESCRIPTION
First of all, I apologize for the size and scope of this pull request -- I started off with what I thought was a simple fix for #7, then I discovered that my change only fixed it for import, not new configuration, and that new configuration was broken for non-AD also.  As I learned my way around the code I fixed about half a dozen other bugs along the way.  I can split this into multiple PRs if you would prefer.

Summary of fixes:
* Move the properties plugin to the top for AD also.
* On new configuration, store activated plugins in the config storage object, so they are moved to the top properly.  (This finally fixes #7 completely.)
* Move the group management plugin to the top (for non-AD), so group memberships can be set via Plone.
* Fix binary flag for schema properties.
* Fix single-value property vocabulary/factory so settings which should not take multivalued attributes (e.g. rDN) are properly limited.
* Store blank property fields as "" rather than None, to avoid getting a literal `'None'` string in the LDAPUserFolder and exported XML.
* When adding mandatory schema items (currently only for AD), store them in the local config object also.  Before they got added to the LDAPUserFolder but did *not* show up in Plone.
* Protect mandatory items from deletion.
* For the AD required schema items, mark objectGUID as binary and add sAMAccountName.
* Fix deprecation warning for the control panel icon.
* Misc. documentation fixes.

Regarding Active Directory, I tried to make my fixes match what I thought the intent was.  I'm not sure if a separate AD plugin is still needed -- from what I can tell, the major differences are (a) read-only access, and (b) it enumerates group membership via the `memberOf` attribute on user objects, rather than the `member` attribute on group objects.

However, the standard LDAP plugin works fine with my AD server for authentication and user information, and RW access works for modifying group membership. (Group addition fails with “server unwilling to perform”, and we want to limit user addition/modification/password change to the AD side, so I haven’t tested those -- it's not 100%, but having some write access is better than none, and reading works fine. Also, nested groups do not appear to work with either plugin, but I don't normally use them.)

My AD groups are presented via LDAP as `group` class objects, with `member` attributes referring to a user’s full DN, much like standard LDAP.  The ```memberOf``` user attribute is still present, but appears to be computed rather than stored in the user object. If the other method was once required, it no longer appears to be.