### PR TITLE
Improved uninstall from component registry.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improved uninstall from component registry.
+  ``ILDAPConfiguration`` still lingered.
+  [maurits]
 
 
 1.4.4 (2019-09-19)

--- a/plone/app/ldap/setuphandlers.py
+++ b/plone/app/ldap/setuphandlers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.app.ldap.engine.interfaces import ILDAPConfiguration
 from Products.CMFCore.utils import getToolByName
 import logging
 
@@ -12,7 +13,31 @@ def uninstall(context):
     pas = getToolByName(context, 'acl_users')
 
     # Remove plugin if it exists.
-    if PLUGIN_ID not in pas.objectIds():
-        return
-    pas._delObject(PLUGIN_ID)
-    logger.info('Removed LDAP plugin %s from acl_users.', PLUGIN_ID)
+    if PLUGIN_ID in pas.objectIds():
+        pas._delObject(PLUGIN_ID)
+        logger.info('Removed LDAP plugin %s from acl_users.', PLUGIN_ID)
+
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    sm = portal.getSiteManager()
+    # The removal in profiles/uninstall/componentregistry.xml does not work correctly,
+    # or not enough.  Presumably this is because the registration contains a factory,
+    # which generates a component on the fly, so the real component
+    # is never actually unregistered.  In code it also has no effect:
+    # sm.unregisterUtility(factory=LDAPConfiguration, provided=ILDAPConfiguration)
+    # So instead we get the real utility.
+    # getUtility(ILDAPConfiguration) already may not work,
+    # so we need a more bare bones approach.
+    ldap_key = (ILDAPConfiguration, u"")
+    if ldap_key not in sm._utility_registrations:
+        logger.info("plone.app.ldap utility is already gone.")
+    else:
+        util = sm._utility_registrations[(ILDAPConfiguration, u"")][0]
+        sm.unregisterUtility(component=util, provided=ILDAPConfiguration, name=u"")
+        logger.info("Unregistered plone.app.ldap utility.")
+    # It may still be in a helper dictionary.
+    if ILDAPConfiguration in sm.utilities._provided:
+        del sm.utilities._provided[ILDAPConfiguration]
+        # _provided is a simple dictionary, not a persistent one,
+        # so we need to signal explicitly that the utilies object has changed.
+        sm.utilities._p_changed = True
+        logger.info("Removed plone.app.ldap interface from utilities._provided.")


### PR DESCRIPTION
`ILDAPConfiguration` still lingered.

After removing the `plone.app.ldap` egg you could still get tracebacks like this,
even when only visiting the Plone Site root in the ZMI:

```
2020-10-14 12:00:40 WARNING OFS.Uninstalled Could not import class 'ILDAPConfiguration' from module 'plone.app.ldap.engine.interfaces'
2020-10-14 12:00:40 ERROR ZODB.Connection Couldn't load state for 0x01408f
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/cp27m/ZODB3-3.10.7-py2.7-macosx-10.14-x86_64.egg/ZODB/Connection.py", line 860, in setstate
    self._setstate(obj)
  File "/Users/maurits/shared-eggs/cp27m/ZODB3-3.10.7-py2.7-macosx-10.14-x86_64.egg/ZODB/Connection.py", line 914, in _setstate
    self._reader.setGhostState(obj, p)
  File "/Users/maurits/shared-eggs/cp27m/ZODB3-3.10.7-py2.7-macosx-10.14-x86_64.egg/ZODB/serialize.py", line 613, in setGhostState
    obj.__setstate__(state)
  File "/Users/maurits/shared-eggs/cp27m/zope.component-3.9.5-py2.7.egg/zope/component/persistentregistry.py", line 40, in __setstate__
    self._createLookup()
  File "/Users/maurits/shared-eggs/cp27m/zope.interface-3.6.8-py2.7-macosx-10.15-x86_64.egg/zope/interface/adapter.py", line 91, in _createLookup
    self._v_lookup = self.LookupClass(self)
  File "/Users/maurits/shared-eggs/cp27m/zope.interface-3.6.8-py2.7-macosx-10.15-x86_64.egg/zope/interface/adapter.py", line 447, in __init__
    self.init_extendors()
  File "/Users/maurits/shared-eggs/cp27m/zope.interface-3.6.8-py2.7-macosx-10.15-x86_64.egg/zope/interface/adapter.py", line 484, in init_extendors
    self.add_extendor(p)
  File "/Users/maurits/shared-eggs/cp27m/zope.interface-3.6.8-py2.7-macosx-10.15-x86_64.egg/zope/interface/adapter.py", line 488, in add_extendor
    for i in provided.__iro__:
AttributeError: type object 'ILDAPConfiguration' has no attribute '__iro__'
```

I added this code in a project where we tried a couple of times to remove `plone.app.ldap` completely (we switched to `pas.plugins.ldap`). So there is a chance that the uninstall profile that I added in 1.4.4 was never run here because we used an earlier version, so maybe that uninstall profile is enough, but it does not look like it.
Anyway, if the new cleanups are not needed, then the conditions will make sure they are not executed.